### PR TITLE
Update AppDelegate.m

### DIFF
--- a/LXNet2OpenDMX/AppDelegate.m
+++ b/LXNet2OpenDMX/AppDelegate.m
@@ -64,7 +64,7 @@
         statusString = @"Missing d2xx. ";
     }
     if ( ! [[NSFileManager defaultManager] fileExistsAtPath:LXUSBDMX_LIBUSB_DRIVER_PATH] ) {
-        [dmxbutton setEnabled:NO];
+        [udmxbutton setEnabled:NO];
         statusString = [NSString stringWithFormat:@"%@Missing libusb.", statusString];
     }
     


### PR DESCRIPTION
"Start Open DMX" button was incorrectly being disabled when libusb was not installed. This fixes that bug.