### PR TITLE
Fix Start/Stop buttons

### DIFF
--- a/LXNet2OpenDMX/AppDelegate.m
+++ b/LXNet2OpenDMX/AppDelegate.m
@@ -146,9 +146,9 @@
 -(void) openDMXStatusUpdate:(NSNotification*) note {
     dmxStatus.ledstate =[[note object] integerValue];
     if ( [openDMXInterface isSending] ) {
-        [dmxbutton setTitle:@"Stop OpenDMX"];
+        //[dmxbutton setTitle:@"Stop OpenDMX"];
     } else {
-        [dmxbutton setTitle:@"Start OpenDMX"];
+        //[dmxbutton setTitle:@"Start OpenDMX"];
     }
 }
 
@@ -182,13 +182,22 @@
     if ( openDMXInterface == NULL ) {
         openDMXInterface = [[LXOpenDMXInterface alloc] init];
         [openDMXInterface startSending];
-    } else {
-        if ( [openDMXInterface isSending] ) {   // STOP
+        if ( [openDMXInterface isSending] ) {
+            [dmxbutton setTitle:@"Stop OpenDMX"];
+        } else {
             [openDMXInterface stopSending];
+            while ( [openDMXInterface isSending] ) {
+                [NSThread sleepForTimeInterval:0.5];
+            }
+            openDMXInterface = NULL;
+            [dmxbutton setTitle:@"Start OpenDMX"];
         }
+    } else {
+        [openDMXInterface stopSending];
         while ( [openDMXInterface isSending] ) {
             [NSThread sleepForTimeInterval:0.5];
         }
+        [dmxbutton setTitle:@"Start OpenDMX"];
         openDMXInterface = NULL;
     }
 }


### PR DESCRIPTION
Losing connection to a dmx device would cause the buttons to become unresponsive and cause problems.

If buttons were pressed before the device was reconnected then the app would need to be restarted to work properly again.